### PR TITLE
Abort if endpoint's status code isn't OK (closes #6)

### DIFF
--- a/src/ar-whitelister.sh
+++ b/src/ar-whitelister.sh
@@ -37,10 +37,12 @@ else
 fi
 clear
 
+echo "Adding IPs to the selected Firewall"
+
 # Process user input
 case "$option" in
 1 | ufw)
-  if [ ! -x "$(command -v ufw)" ]; then
+  if [[ ! -x "$(command -v ufw)" ]]; then
     abort "ufw is not installed."
   fi
 
@@ -50,7 +52,7 @@ case "$option" in
   sudo ufw reload
   ;;
 2 | csf)
-  if [ ! -x "$(command -v csf)" ]; then
+  if [[ ! -x "$(command -v csf)" ]]; then
     abort "csf is not installed."
   fi
 
@@ -60,7 +62,7 @@ case "$option" in
   sudo csf -r
   ;;
 3 | firewalld)
-  if [ ! -x "$(command -v firewall-cmd)" ]; then
+  if [[ ! -x "$(command -v firewall-cmd)" ]]; then
     abort "firewalld is not installed."
   fi
 

--- a/src/ar-whitelister.sh
+++ b/src/ar-whitelister.sh
@@ -31,7 +31,7 @@ IPsFile=$(mktemp /tmp/ar-ips.XXXXXX)
 # Delete the temp file if the script stopped for any reason
 trap 'rm -f ${IPsFile}' 0 2 3 15
 
-if [[ ! -x "$(command -v curl)" ]]; then
+if [[ -x "$(command -v curl)" ]]; then
   downloadStatus=$(curl "${IPsLink}" -o "${IPsFile}" -L -s -w "%{http_code}\n")
 elif [[ -x "$(command -v wget)" ]]; then
   downloadStatus=$(wget "${IPsLink}" -O "${IPsFile}" --server-response 2>&1 | awk '/^  HTTP/{print $2}' | tail -n1)


### PR DESCRIPTION
Apologizing for the delay, I was checking the latest news about ArvanCloud.

It now:
- Follow redirects
- Abort the process if [the endpoint](https://www.arvancloud.com/fa/ips.txt)'s response is not equal with 200.